### PR TITLE
docs: Fix unescaped backtick in logs_destinations_ids description

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 This Terraform module creates an [Azure Kubernetes Service](https://azure.microsoft.com/fr-fr/services/kubernetes-service/).
 
-Non-exhaustive feature list, most of them can be overriden:
+Non-exhaustive feature list, most of them can be overridden:
 
 * Cluster created with [User Assigned identity](https://learn.microsoft.com/en-us/azure/aks/use-managed-identity#bring-your-own-control-plane-managed-identity), and related role assignments are managed, for better dependencies lifecycle management
 * Default [latest stable Kubernetes version](https://learn.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli#aks-kubernetes-release-calendar) used at creation
@@ -283,7 +283,7 @@ module "aks" {
 | location | Azure region to use. | `string` | n/a | yes |
 | location\_short | Short string for Azure location. | `string` | n/a | yes |
 | logs\_categories | Log categories to send to destinations. | `list(string)` | `null` | no |
-| logs\_destinations\_ids | List of destination resources IDs for logs diagnostic destination.<br>Can be `Storage Account`, `Log Analytics Workspace` and `Event Hub`. No more than one of each can be set.<br>If you want to specify an Azure EventHub to send logs and metrics to, you need to provide a formated string with both the EventHub Namespace authorization send ID and the EventHub name (name of the queue to use in the Namespace) separated by the `|` character. | `list(string)` | n/a | yes |
+| logs\_destinations\_ids | List of destination resources IDs for logs diagnostic destination.<br>Can be `Storage Account`, `Log Analytics Workspace` and `Event Hub`. No more than one of each can be set.<br>If you want to specify an Azure EventHub to send logs and metrics to, you need to provide a formated string with both the EventHub Namespace authorization send ID and the EventHub name (name of the queue to use in the Namespace) separated by the `pipe` (\\|) character. | `list(string)` | n/a | yes |
 | logs\_kube\_audit\_enabled | Whether to include `kube-audit` and `kube-audit-admin` logs from diagnostics settings collection. Enabling this can increase your Azure billing. | `bool` | `false` | no |
 | logs\_metrics\_categories | Metrics categories to send to destinations. | `list(string)` | `null` | no |
 | name\_prefix | Optional prefix for the generated name | `string` | `""` | no |

--- a/variables-logs.tf
+++ b/variables-logs.tf
@@ -5,7 +5,7 @@ variable "logs_destinations_ids" {
   description = <<EOD
 List of destination resources IDs for logs diagnostic destination.
 Can be `Storage Account`, `Log Analytics Workspace` and `Event Hub`. No more than one of each can be set.
-If you want to specify an Azure EventHub to send logs and metrics to, you need to provide a formated string with both the EventHub Namespace authorization send ID and the EventHub name (name of the queue to use in the Namespace) separated by the `|` character.
+If you want to specify an Azure EventHub to send logs and metrics to, you need to provide a formated string with both the EventHub Namespace authorization send ID and the EventHub name (name of the queue to use in the Namespace) separated by the `pipe` (\|) character.
 EOD
 }
 


### PR DESCRIPTION
This breaks the rendered description 

![image](https://github.com/claranet/terraform-azurerm-aks-light/assets/80741/b46cbefd-3083-4118-a601-cf77626f5551)

I replaced `|` with "pipe" word because I don't know how to universally escape backtick for both, HCL `description` presumably input for the terraform-docs as well as GitHub Markdown.
