### PR TITLE
Avoid using `for_each` when list values are not calculated

### DIFF
--- a/r-rbac.tf
+++ b/r-rbac.tf
@@ -40,9 +40,9 @@ resource "azurerm_role_assignment" "aks_kubelet_uai_nodes_rg_contributor" {
 
 # Allow Kubelet Identity to authenticate with Azure Container Registry (ACR)
 resource "azurerm_role_assignment" "aks_kubelet_uai_acr_pull" {
-  for_each = toset(var.container_registries_ids)
+  count = length(var.container_registries_ids)
 
-  scope                = each.key
+  scope                = var.container_registries_ids[count.index]
   principal_id         = azurerm_kubernetes_cluster.aks.kubelet_identity[0].object_id
   role_definition_name = "AcrPull"
 }

--- a/r-rbac.tf
+++ b/r-rbac.tf
@@ -45,6 +45,10 @@ resource "azurerm_role_assignment" "aks_kubelet_uai_acr_pull" {
   scope                = var.container_registries_ids[count.index]
   principal_id         = azurerm_kubernetes_cluster.aks.kubelet_identity[0].object_id
   role_definition_name = "AcrPull"
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 # Role assignment for ACI, if ACI is enabled


### PR DESCRIPTION
See #10 for more explanation

Fixes #(issue) .

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes proposed in this pull request
In short, this is avoiding `for_each` when list members have unknown values. This is a problem as these values are attempted to be used as keys for the unique address of each resource being created by `for_each` iteration, which Terraform refuses to do.

This will cause a recreation of `azurerm_role_assignment` resources

@claranet/fr-azure-reviewers
